### PR TITLE
PT-9 - PT-9-tests-for-exception-classes

### DIFF
--- a/src/Exceptions/InvalidHashAlgorithmException.php
+++ b/src/Exceptions/InvalidHashAlgorithmException.php
@@ -52,7 +52,7 @@ class InvalidHashAlgorithmException extends TotpException
      *
      * @return string The algorithm name.
      */
-    public function getAlgorithm(): string
+    public function getHashAlgorithm(): string
     {
         return $this->m_algorithm;
     }

--- a/src/Exceptions/UrlGenerator/UnsupportedRendererException.php
+++ b/src/Exceptions/UrlGenerator/UnsupportedRendererException.php
@@ -63,7 +63,7 @@ class UnsupportedRendererException extends UrlGeneratorException
      *
      * @return string The renderer class name.
      */
-    public function rendererClass(): string
+    public function getRendererClass(): string
     {
         return get_class($this->getRenderer());
     }

--- a/tests/Exceptions/InvalidBase32DataExceptionTest.php
+++ b/tests/Exceptions/InvalidBase32DataExceptionTest.php
@@ -1,0 +1,127 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions;
+
+use Equit\Totp\Exceptions\InvalidBase32DataException;
+use Equit\Totp\Tests\Framework\TestCase;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidBase32DataException class.
+ */
+class InvalidBase32DataExceptionTest extends TestCase
+{
+    /**
+     * Generate a random string that is guaranteed not to be a valid Base32 string.
+     *
+     * @return string The generated string.
+     */
+    private static function randomInvalidBase32String(): string
+    {
+        static $alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+
+        $str = "_";
+
+        for ($length = mt_rand(4, 24); 0 !== $length; --$length) {
+            $str .= $alphabet[mt_rand(0, strlen($alphabet) - 1)];
+        }
+
+        return $str;
+    }
+
+    /**
+     * Test data for InvalidBase32DataException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typicalDataOnly" => ["blah",],
+            "typicalDataAndMessage" => ["blah", "'blah' is not valid base32 content.",],
+            "typicalDataMessageAndCode" => ["blah", "'blah' is not valid base32 content.", 12,],
+            "typicalDataMessageCodeAndPrevious" => ["blah", "'blah' is not valid base32 content.", 12, new Exception("foo"),],
+            "invalidNullData" => [null, "null is not valid base32 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableData" => [self::createStringable("blah"), "'blah' is not valid base32 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidIntData" => [1, "1 is not valid base32 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatData" => [1.115, "1.115 is not valid base32 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueData" => [true, "true is not valid base32 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseData" => [false, "false is not valid base32 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayData" => [["blah",], "['blah'] is not valid base32 content.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the InvalidBase32DataException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $data The invalid base32 data for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $data, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidBase32DataException($data, $message, $code, $previous);
+        $this->assertEquals($data, $exception->getData(), "Invalid Base32 data retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidBase32DataException::getData().
+     *
+     * @return \Generator
+     */
+    public function dataForTestGetData(): Generator
+    {
+        yield from [
+            "typical" => ["fizzbuzz",],
+            "extremeEmpty" => ["",],
+        ];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "typicalRandom" . sprintf("%02d", $idx) => [self::randomInvalidBase32String(),];
+        }
+    }
+
+    /**
+     * Test the InvalidBase32DataException::getData() method.
+     *
+     * @dataProvider dataForTestGetData
+     *
+     * @param string $data The data to test with.
+     */
+    public function testGetData(string $data): void
+    {
+        $exception = new InvalidBase32DataException($data);
+        $this->assertEquals($data, $exception->getData(), "Invalid Base32 data retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/InvalidBase64DataExceptionTest.php
+++ b/tests/Exceptions/InvalidBase64DataExceptionTest.php
@@ -1,0 +1,127 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions;
+
+use Equit\Totp\Exceptions\InvalidBase64DataException;
+use Equit\Totp\Tests\Framework\TestCase;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidBase64DataException class.
+ */
+class InvalidBase64DataExceptionTest extends TestCase
+{
+    /**
+     * Generate a random string that is guaranteed not to be a valid Base64 string.
+     *
+     * @return string The generated string.
+     */
+    private static function randomInvalidBase64String(): string
+    {
+        static $alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+
+        $str = "_";
+
+        for ($length = mt_rand(4, 24); 0 !== $length; --$length) {
+            $str .= $alphabet[mt_rand(0, strlen($alphabet) - 1)];
+        }
+
+        return $str;
+    }
+
+    /**
+     * Test data for InvalidBase64DataException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typicalDataOnly" => ["blah_:",],
+            "typicalDataAndMessage" => ["blah_:", "'blah_:' is not valid base64 content.",],
+            "typicalDataMessageAndCode" => ["blah_:", "'blah_:' is not valid base64 content.", 12,],
+            "typicalDataMessageCodeAndPrevious" => ["blah_:", "'blah_:' is not valid base64 content.", 12, new Exception("foo"),],
+            "invalidNullData" => [null, "null is not valid base64 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableData" => [self::createStringable("blah_:"), "'blah_:' is not valid base64 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidIntData" => [1, "1 is not valid base64 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatData" => [1.115, "1.115 is not valid base64 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueData" => [true, "true is not valid base64 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseData" => [false, "false is not valid base64 content.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayData" => [["blah_:",], "['blah_:'] is not valid base64 content.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the InvalidBase64DataException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $data The invalid base64 data for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $data, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidBase64DataException($data, $message, $code, $previous);
+        $this->assertEquals($data, $exception->getData(), "Invalid Base64 data retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidBase64DataException::getData().
+     *
+     * @return Generator
+     */
+    public function dataForTestGetData(): Generator
+    {
+        yield from [
+            "typical" => ["fizzbuzz",],
+            "extremeEmpty" => ["",],
+        ];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "typicalRandom" . sprintf("%02d", $idx) => [self::randomInvalidBase64String(),];
+        }
+    }
+
+    /**
+     * Test the InvalidBase64DataException::getData() method.
+     *
+     * @dataProvider dataForTestGetData
+     *
+     * @param string $data The data to test with.
+     */
+    public function testGetData(string $data): void
+    {
+        $exception = new InvalidBase64DataException($data);
+        $this->assertEquals($data, $exception->getData(), "Invalid Base64 data retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/InvalidDigitsExceptionTest.php
+++ b/tests/Exceptions/InvalidDigitsExceptionTest.php
@@ -1,0 +1,115 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions;
+
+use Equit\Totp\Exceptions\InvalidDigitsException;
+use Equit\Totp\Tests\Framework\TestCase;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidDigitsException class.
+ */
+class InvalidDigitsExceptionTest extends TestCase
+{
+
+    /**
+     * Test data for InvalidDigitsException constructor.
+     *
+     * @return Generator The test data.
+     */
+    public function dataForTestConstructor(): Generator
+    {
+        for ($digits = 1; $digits < 6; ++$digits) {
+            yield "typical{$digits}" => [$digits];
+        }
+
+        yield from [
+            "typicalDigitsAndMessage" => [1, "1 is not a valid number of digits.",],
+            "typicalDigitsMessageAndCode" => [1, "1 is not a valid number of digits.", 12,],
+            "typicalDigitsMessageCodeAndPrevious" => [1, "1 is not a valid number of digits.", 12, new Exception("foo"),],
+            "invalidNullDigits" => [null, "Null is not a valid number of digits.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringDigits" => ["1", "'1' is not a valid number of digits.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatDigits" => [1.115, "1.115 is not a valid number of digits.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueDigits" => [true, "True is not a valid number of digits.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseDigits" => [false, "False is not a valid number of digits.", 12, new Exception("foo"), TypeError::class],
+            "invalidObjectDigits" => [(object)["digits" => 1,], "This is not a valid number of digits.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableDigits" => [self::createStringable("1"), "'1' is not a valid number of digits.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayDigits" => [[1,], "[1] is not a valid number of digits.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the InvalidDigitsException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $digits The invalid number of digits for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $digits, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidDigitsException($digits, $message, $code, $previous);
+        $this->assertEquals($digits, $exception->getDigits(), "Invalid number of digits retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidDigitsException::getDigits().
+     *
+     * @return \Generator
+     */
+    public function dataForTestGetDigits(): Generator
+    {
+        yield from [
+            "typical" => [5,],
+            "extremeZero" => [0,],
+            "extremeMinus7" => [-7,],
+        ];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "random" . sprintf("%02d", $idx) => [mt_rand(PHP_INT_MIN, 5),];
+        }
+    }
+
+    /**
+     * Test the InvalidDigitsException::getDigits() method.
+     *
+     * @dataProvider dataForTestGetDigits
+     *
+     * @param int $digits The number of digits to test with.
+     */
+    public function testGetDigits(int $digits): void
+    {
+        $exception = new InvalidDigitsException($digits);
+        $this->assertEquals($digits, $exception->getDigits(), "Invalid number of digits retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/InvalidHashAlgorithmExceptionTest.php
+++ b/tests/Exceptions/InvalidHashAlgorithmExceptionTest.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions;
+
+use Equit\Totp\Exceptions\InvalidHashAlgorithmException;
+use Equit\Totp\Tests\Framework\TestCase;
+use Equit\Totp\Totp;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidHashAlgorithmException class.
+ */
+class InvalidHashAlgorithmExceptionTest extends TestCase
+{
+    /**
+     * Generate a random string that is guaranteed not to be a valid TOTP hash algorithm.
+     *
+     * The string returned will be one of the algorithms that is supported by PHP but is not valid for TOTP.
+     *
+     * @return string The generated invalid algorithm.
+     */
+    private static function randomInvalidAlgorithm(): string
+    {
+        static $algorithms = null;
+
+        if (!isset($algorithms)) {
+            $algorithms = array_values(array_filter(hash_algos(), fn(string $algorithm): bool => match ($algorithm) {
+                Totp::Sha1Algorithm, Totp::Sha256Algorithm, Totp::Sha512Algorithm => false,
+                default => true,
+            }));
+        }
+
+        return $algorithms[mt_rand(0, count($algorithms) - 1)];
+    }
+
+    /**
+     * Test data for InvalidHashAlgorithmException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typicalAlgorithmOnly" => ["md5",],
+            "typicalAlgorithmAndMessage" => ["md5", "'md5' is not a valid TOTP hash algorithm.",],
+            "typicalAlgorithmMessageAndCode" => ["md5", "'md5' is not a valid TOTP hash algorithm.", 12,],
+            "typicalAlgorithmMessageCodeAndPrevious" => ["md5", "'md5' is not a valid TOTP hash algorithm.", 12, new Exception("foo"),],
+            "invalidNullAlgorithm" => [null, "null is not a valid TOTP hash algorithm.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableAlgorithm" => [self::createStringable("md5"), "'md5' is not a valid TOTP hash algorithm.", 12, new Exception("foo"), TypeError::class],
+            "invalidIntAlgorithm" => [1, "1 is not a valid TOTP hash algorithm.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatAlgorithm" => [1.115, "1.115 is not a valid TOTP hash algorithm.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueAlgorithm" => [true, "true is not a valid TOTP hash algorithm.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseAlgorithm" => [false, "false is not a valid TOTP hash algorithm.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayAlgorithm" => [["md5",], "'md5' is not a valid TOTP hash algorithm.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the InvalidHashAlgorithmException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $hashAlgorithm The invalid algorithm for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $hashAlgorithm, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidHashAlgorithmException($hashAlgorithm, $message, $code, $previous);
+        $this->assertEquals($hashAlgorithm, $exception->getHashAlgorithm(), "Invalid hash algorithm retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidHashAlgorithmException::getAlgorithm().
+     *
+     * @return Generator
+     */
+    public function dataForTestGetAlgorithm(): Generator
+    {
+        yield from [
+            "typical" => ["md5",],
+            "extremeEmpty" => ["",],
+            "extremeNearlyValid" => ["sha1 ",],
+        ];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "typicalRandom" . sprintf("%02d", $idx) => [self::randomInvalidAlgorithm(),];
+        }
+    }
+
+    /**
+     * Test the InvalidHashAlgorithmException::getHashAlgorithm() method.
+     *
+     * @dataProvider dataForTestGetAlgorithm
+     *
+     * @param string $secret The algorithm to test with.
+     */
+    public function testGetAlgorithm(string $secret): void
+    {
+        $exception = new InvalidHashAlgorithmException($secret);
+        $this->assertEquals($secret, $exception->getHashAlgorithm(), "Invalid hash algorithm retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/InvalidIntervalExceptionTest.php
+++ b/tests/Exceptions/InvalidIntervalExceptionTest.php
@@ -1,0 +1,112 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions;
+
+use Equit\Totp\Exceptions\InvalidIntervalException;
+use Equit\Totp\Tests\Framework\TestCase;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidIntervalException class.
+ */
+class InvalidIntervalExceptionTest extends TestCase
+{
+
+    /**
+     * Test data for InvalidIntervalException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typical0" => [0],
+            "typicalIntervalMessageAndCode" => [0, "0 is not a valid interval.", 12,],
+            "typicalIntervalMessageCodeAndPrevious" => [0, "0 is not a valid interval.", 12, new Exception("foo"),],
+            "extremeMinus1" => [-1,],
+            "extremeIntMin" => [PHP_INT_MIN,],
+            "invalidNullInterval" => [null, "null is not a valid interval.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringInterval" => ["0", "'0'' is not a valid interval.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatInterval" => [0.15, "0.15 is not a valid interval.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueInterval" => [true, "true is not a valid interval.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseInterval" => [false, "false is not a valid interval.", 12, new Exception("foo"), TypeError::class],
+            "invalidObjectInterval" => [(object)["interval" => 1,], "This is not a valid interval.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayInterval" => [[0,], "[0] is not a valid interval.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the InvalidIntervalException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $interval The invalid interval for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $interval, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidIntervalException($interval, $message, $code, $previous);
+        $this->assertEquals($interval, $exception->getInterval(), "Invalid interval retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidIntervalException::getInterval().
+     *
+     * @return \Generator
+     */
+    public function dataForTestGetInterval(): Generator
+    {
+        yield from [
+            "typical" => [0,],
+            "extremeMinus1" => [-1,],
+            "extremeIntMin" => [PHP_INT_MIN,],
+        ];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "random" . sprintf("%02d", $idx) => [mt_rand(PHP_INT_MIN, 0),];
+        }
+    }
+
+    /**
+     * Test the InvalidIntervalException::getInterval() method.
+     *
+     * @dataProvider dataForTestGetInterval
+     *
+     * @param int $interval The interval to test with.
+     */
+    public function testGetInterval(int $interval): void
+    {
+        $exception = new InvalidIntervalException($interval);
+        $this->assertEquals($interval, $exception->getInterval(), "Invalid interval retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/InvalidSecretExceptionTest.php
+++ b/tests/Exceptions/InvalidSecretExceptionTest.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions;
+
+use Equit\Totp\Exceptions\InvalidSecretException;
+use Equit\Totp\Tests\Framework\TestCase;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidSecretException class.
+ */
+class InvalidSecretExceptionTest extends TestCase
+{
+    /**
+     * Generate a random string that is guaranteed not to be a valid Totp secret.
+     *
+     * @return string The generated invalid secret.
+     */
+    private static function randomInvalidSecret(): string
+    {
+        return random_bytes(mt_rand(1, 15));
+    }
+
+    /**
+     * Test data for InvalidSecretException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typicalSecretOnly" => ["blah_:",],
+            "typicalSecretAndMessage" => ["blah_:", "'blah_:' is not a valid TOTP secret.",],
+            "typicalSecretMessageAndCode" => ["blah_:", "'blah_:' is not a valid TOTP secret.", 12,],
+            "typicalSecretMessageCodeAndPrevious" => ["blah_:", "'blah_:' is not a valid TOTP secret.", 12, new Exception("foo"),],
+            "invalidNullSecret" => [null, "null is not a valid TOTP secret.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableSecret" => [self::createStringable("blah_:"), "'blah_:' is not a valid TOTP secret.", 12, new Exception("foo"), TypeError::class],
+            "invalidIntSecret" => [1, "1 is not a valid TOTP secret.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatSecret" => [1.115, "1.115 is not a valid TOTP secret.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueSecret" => [true, "true is not a valid TOTP secret.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseSecret" => [false, "false is not a valid TOTP secret.", 12, new Exception("foo"), TypeError::class],
+            "invalidObjectSecret" => [(object)["secret" => "blah_:",], "object is not a valid TOTP secret.", 12, new Exception("foo"), TypeError::class],
+            "invalidArraySecret" => [["blah_:",], "'blah_:' is not a valid TOTP secret.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the InvalidSecretException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $secret The invalid secret for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $secret, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidSecretException($secret, $message, $code, $previous);
+        $this->assertEquals($secret, $exception->getSecret(), "Invalid secret retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidSecretException::getSecret().
+     *
+     * @return Generator
+     */
+    public function dataForTestGetSecret(): Generator
+    {
+        yield from [
+            "typical" => ["fizzbuzz",],
+            "extremeEmpty" => ["",],
+            "extremeNearestInvalid" => ["bvcoaw872bkjsdn",],
+        ];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "typicalRandom" . sprintf("%02d", $idx) => [self::randomInvalidSecret(),];
+        }
+    }
+
+    /**
+     * Test the InvalidSecretException::getSecret() method.
+     *
+     * @dataProvider dataForTestGetSecret
+     *
+     * @param string $secret The secret to test with.
+     */
+    public function testGetSecret(string $secret): void
+    {
+        $exception = new InvalidSecretException($secret);
+        $this->assertEquals($secret, $exception->getSecret(), "Invalid secret retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/InvalidTimeExceptionTest.php
+++ b/tests/Exceptions/InvalidTimeExceptionTest.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions;
+
+use Equit\Totp\Exceptions\InvalidTimeException;
+use Equit\Totp\Tests\Framework\TestCase;
+use DateTime;
+use DateTimeZone;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidTimeException class.
+ */
+class InvalidTimeExceptionTest extends TestCase
+{
+    /**
+     * Test data for InvalidTimeException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typicalTimestamp0" => [0,],
+            "typicalTimestamp60" => [60,],
+            "typicalTimestampNow" => [time(),],
+            "typicalTimestampAndMessage" => [0, "0 is not a valid time.",],
+            "typicalTimestampMessageAndCode" => [0, "0 is not a valid time.", 12,],
+            "typicalTimestampMessageCodeAndPrevious" => [0, "0 is not a valid time.", 12, new Exception("foo"),],
+            "extremeIntMin" => [PHP_INT_MIN,],
+            "invalidNullTime" => [null, "null is not a valid time.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringTime" => ["1970-01-01 00:00:00", "'1970-01-01 00:00:00' is not a valid time.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableTime" => [self::createStringable("1970-01-01 00:00:00"), "'1970-01-01 00:00:00' is not a valid time.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatTime" => [0.15, "0.15 is not a valid time.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueTime" => [true, "true is not a valid time.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseTime" => [false, "false is not a valid time.", 12, new Exception("foo"), TypeError::class],
+            "invalidObjectTime" => [(object)["time" => "1970-01-01 00:00:00",], "object is not a valid time.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayTime" => [["1970-01-01 00:00:00",], "['1970-01-01 00:00:00'] is not a valid time.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the InvalidTimeException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $timestamp The invalid time for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     *
+     * @noinspection PhpDocMissingThrowsInspection DateTime constructor should not throw with timestamp argument.
+     */
+    public function testConstructor(mixed $timestamp, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidTimeException($timestamp, $message, $code, $previous);
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with timestamp argument. */
+        $time = new DateTime("@{$timestamp}", new DateTimeZone("UTC"));
+
+        $this->assertEquals($time, $exception->getDateTime(), "DateTime retrieved from exception was not as expected.");
+        $this->assertEquals($timestamp, $exception->getTimestamp(), "Timestamp retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidTimeException::getTimestamp().
+     *
+     * @return \Generator
+     */
+    public function dataForTestGetTimestamp(): Generator
+    {
+        yield from [
+            "typical0" => [0,],
+            "extremeIntMin" => [PHP_INT_MIN,],
+        ];
+
+        yield "typicalNow" => [time(),];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "random" . sprintf("%02d", $idx) => [mt_rand(PHP_INT_MIN, PHP_INT_MAX),];
+        }
+    }
+
+    /**
+     * Test the InvalidTimeException::getTimestamp() method.
+     *
+     * @dataProvider dataForTestGetTimestamp
+     *
+     * @param int $timestamp The timestamp to test with.
+     */
+    public function testGetTimestamp(int $timestamp): void
+    {
+        $exception = new InvalidTimeException($timestamp);
+        $this->assertEquals($timestamp, $exception->getTimestamp(), "Invalid timestamp retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidTimeException::getDateTime().
+     *
+     * @return \Generator
+     * @noinspection PhpDocMissingThrowsInspection DateTime constructor should not throw with timestamp argument.
+     */
+    public function dataForTestGetDateTime(): Generator
+    {
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with timestamp argument. */
+        yield from [
+            "typical0" => [0, new DateTime("@0", new DateTimeZone("UTC")),],
+            "extremeIntMin" => [PHP_INT_MIN, new DateTime("@" . PHP_INT_MIN, new DateTimeZone("UTC")),],
+        ];
+
+        $now = time();
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with timestamp argument. */
+        yield "now" => [$now, new DateTime("@{$now}", new DateTimeZone("UTC")),];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            $time = mt_rand(PHP_INT_MIN, PHP_INT_MAX);
+            yield "random" . sprintf("%02d", $idx) => [$time, new DateTime("@{$time}", new DateTimeZone("UTC")),];
+        }
+    }
+
+    /**
+     * Test the InvalidTimeException::getDateTime() method.
+     *
+     * @dataProvider dataForTestGetDateTime
+     *
+     * @param int $timestamp The timestamp to use to initialise the test exception.
+     * @param \DateTime $expectedTime The expected value returned from getDateTime().
+     */
+    public function testGetDateTime(int $timestamp, DateTime $expectedTime): void
+    {
+        $exception = new InvalidTimeException($timestamp);
+        $this->assertEquals($expectedTime, $exception->getDateTime(), "Invalid DateTime retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/InvalidVerificationWindowExceptionTest.php
+++ b/tests/Exceptions/InvalidVerificationWindowExceptionTest.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions;
+
+use Equit\Totp\Exceptions\InvalidVerificationWindowException;
+use Equit\Totp\Tests\Framework\TestCase;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidVerificationWindowException class.
+ */
+class InvalidVerificationWindowExceptionTest extends TestCase
+{
+    /**
+     * Test data for InvalidVerificationWindowException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typicalMinus1" => [-1],
+            "typicalIntervalMessageAndCode" => [-1, "-1 is not a valid verification window.", 12,],
+            "typicalIntervalMessageCodeAndPrevious" => [-1, "-1 is not a valid verification window.", 12, new Exception("foo"),],
+            "extremeIntMin" => [PHP_INT_MIN,],
+            "invalidNullWindow" => [null, "null is not a valid verification window.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringWindow" => ["-1", "'-1' is not a valid verification window.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatWindow" => [0.15, "0.15 is not a valid verification window.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueWindow" => [true, "true is not a valid verification window.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseWindow" => [false, "false is not a valid verification window.", 12, new Exception("foo"), TypeError::class],
+            "invalidObjectWindow" => [(object)["window" => -1,], "object is not a valid verification window.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayWindow" => [[-1,], "[-1] is not a valid verification window.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for InvalidVerificationWindowException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $window The invalid window for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $window, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidVerificationWindowException($window, $message, $code, $previous);
+        $this->assertEquals($window, $exception->getWindow(), "Invalid window retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidVerificationWindowException::getWindow().
+     *
+     * @return \Generator
+     */
+    public function dataForTestGetWindow(): Generator
+    {
+        yield from [
+            "typicalMinus1" => [-1,],
+            "extremeIntMin" => [PHP_INT_MIN,],
+        ];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "random" . sprintf("%02d", $idx) => [mt_rand(PHP_INT_MIN, -1),];
+        }
+    }
+
+    /**
+     * Test the InvalidVerificationWindowException::getWindow() method.
+     *
+     * @dataProvider dataForTestGetWindow
+     *
+     * @param int $window The window to test with.
+     */
+    public function testGetWindow(int $window): void
+    {
+        $exception = new InvalidVerificationWindowException($window);
+        $this->assertEquals($window, $exception->getWindow(), "Invalid window retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/UrlGenerator/InvalidUserExceptionTest.php
+++ b/tests/Exceptions/UrlGenerator/InvalidUserExceptionTest.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions\UrlGenerator;
+
+use Equit\Totp\Exceptions\UrlGenerator\InvalidUserException;
+use Equit\Totp\Tests\Framework\TestCase;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the InvalidUserException class.
+ */
+class InvalidUserExceptionTest extends TestCase
+{
+    /**
+     * Generate a random user string.
+     *
+     * @return string The generated user.
+     */
+    private static function randomUser(): string
+    {
+        static $users = [
+            "darren", "Susan", "clive", "mo.iqbal", "peggy-sue", "Art.Garfunkel", "david", "superuser", "administrator", "COLIN",
+            "MARK", "abney", "Abbey", "abi", "sami", "Usman", "imran", "urma", "Ootha", "forbes",
+            "ruariadh", "conor", "chuck", "Chet", "mowgli", "abu", "Herman", "FRANCOISE", "cortana", "siri",
+            "alexa", "mortimer", "zbigniew", "Alasdair", "Michael", "filip", "Sven", "jacqui", "peter", "petra",
+        ];
+
+        return $users[mt_rand(0, count($users) - 1)];
+    }
+
+    /**
+     * Test data for InvalidUserException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typicalUserOnly" => ["",],
+            "typicalUserAndMessage" => ["", "'' is not a valid user.",],
+            "typicalUserMessageAndCode" => ["", "'' is not a valid user.", 12,],
+            "typicalUserMessageCodeAndPrevious" => ["", "'' is not a valid user.", 12, new Exception("foo"),],
+            "invalidNullUser" => [null, "null is not a valid user.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableUser" => [self::createStringable(""), "'' is not a valid user.", 12, new Exception("foo"), TypeError::class],
+            "invalidIntUser" => [1, "1 is not a valid user.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatUser" => [1.115, "1.115 is not a valid user.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueUser" => [true, "true is not a valid user.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseUser" => [false, "false is not a valid user.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayUser" => [["",], "[''] is not a valid user.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the InvalidUserException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $user The invalid user for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $user, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new InvalidUserException($user, $message, $code, $previous);
+        $this->assertEquals($user, $exception->getUser(), "Invalid user retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for InvalidUserException::getUser().
+     *
+     * @return Generator
+     */
+    public function dataForTestGetUser(): Generator
+    {
+        yield from [
+            "typicalEmpty" => ["",],
+            "typicalFilled" => ["darren",],
+        ];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            yield "typicalRandom" . sprintf("%02d", $idx) => [self::randomUser(),];
+        }
+    }
+
+    /**
+     * Test the InvalidUserException::getUser() method.
+     *
+     * @dataProvider dataForTestGetUser
+     *
+     * @param string $user The user to test with.
+     */
+    public function testGetUser(string $user): void
+    {
+        $exception = new InvalidUserException($user);
+        $this->assertEquals($user, $exception->getUser(), "Invalid user retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/UrlGenerator/UnsupportedReferenceTimeExceptionTest.php
+++ b/tests/Exceptions/UrlGenerator/UnsupportedReferenceTimeExceptionTest.php
@@ -1,0 +1,229 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions\UrlGenerator;
+
+use Equit\Totp\Exceptions\UrlGenerator\UnsupportedReferenceTimeException;
+use Equit\Totp\Tests\Framework\TestCase;
+use DateTime;
+use DateTimeZone;
+use Exception;
+use Generator;
+use InvalidArgumentException;
+use TypeError;
+
+/**
+ * Unit test for the UnsupportedReferenceTimeException class.
+ */
+class UnsupportedReferenceTimeExceptionTest extends TestCase
+{
+    /**
+     * When generating random timestamps, the earliest will be 80 years before the Unix epoch.
+     */
+    private const MinTimestamp = -80 * 365 * 24 * 60 * 60;
+
+    /**
+     * When generating random timestamps, the latest will be 80 years after the Unix epoch.
+     */
+    private const MaxTimestamp = 80 * 365 * 24 * 60 * 60;
+
+    /**
+     * Test data for UnsupportedReferenceTimeException constructor.
+     *
+     * @return array The test data.
+     * @noinspection PhpDocMissingThrowsInspection DateTime constructor should not throw with timestamp argument.
+     */
+    public function dataForTestConstructor(): array
+    {
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with timestamp argument. */
+        return [
+            "typicalTimestamp60" => [60,],
+            "typicalTimestamp120" => [120,],
+            "typicalTimestampNow" => [time(),],
+            "typicalDateTime60" => [new DateTime("@60", new DateTimeZone("UTC")),],
+            "typicalDateTime120" => [new DateTime("@120", new DateTimeZone("UTC")),],
+            "typicalDateTimeNow" => [new DateTime("@" . time(), new DateTimeZone("UTC")),],
+            "typicalTimestampAndMessage" => [60, "60 is not a valid reference time.",],
+            "typicalTimestampMessageAndCode" => [60, "60 is not a valid reference time.", 12,],
+            "typicalTimestampMessageCodeAndPrevious" => [60, "60 is not a valid reference time.", 12, new Exception("foo"),],
+            "typicalDateTimeAndMessage" => [new DateTime("@60", new DateTimeZone("UTC")), "60 is not a valid reference time.",],
+            "typicalDateTimeMessageAndCode" => [new DateTime("@60", new DateTimeZone("UTC")), "60 is not a valid reference time.", 12,],
+            "typicalDateTimeMessageCodeAndPrevious" => [new DateTime("@60", new DateTimeZone("UTC")), "60 is not a valid reference time.", 12, new Exception("foo"),],
+            "extremeVeryEarly" => [self::MinTimestamp,],
+            "extremeVeryLate" => [self::MaxTimestamp,],
+            "invalidNullTime" => [null, "null is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringTime" => ["1970-01-01 00:01:00", "'1970-01-01 00:01:00' is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableTimestamp" => [self::createStringable("0"), "'0' is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableDateTime" => [self::createStringable("1970-01-01 00:01:00"), "'1970-01-01 00:01:00' is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatTime" => [0.15, "0.15 is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueTime" => [true, "true is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseTime" => [false, "false is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidObjectTimeastamp" => [(object)["time" => 60,], "object is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidObjectDateTime" => [(object)["time" => "1970-01-01 00:01:00",], "object is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayTimestamp" => [[60,], "[60] is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayTime" => [["1970-01-01 00:01:00",], "'1970-01-01 00:01:00' is not a valid reference time.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for the UnsupportedReferenceTimeException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $time The invalid time for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     *
+     * @noinspection PhpDocMissingThrowsInspection DateTime constructor should not throw with timestamp argument.
+     */
+    public function testConstructor(mixed $time, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new UnsupportedReferenceTimeException($time, $message, $code, $previous);
+
+        if ($time instanceof DateTime) {
+            $timestamp = $time->getTimestamp();
+        } else {
+            if (is_int($time)) {
+                $timestamp = $time;
+                /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with a timestamp argument. */
+                $time = new DateTime("@{$time}", new DateTimeZone("UTC"));
+            } else {
+                if (!isset($exceptionClass)) {
+                    throw new InvalidArgumentException("\$time is not a timestamp nor a DateTime - we should be expecting an exception but we're not.");
+                }
+            }
+        }
+
+        $this->assertEquals($time, $exception->getTime(), "Unsupported DateTime retrieved from exception was not as expected.");
+        /** @noinspection PhpUndefinedVariableInspection We know $timestamp is defined because the only branch that doesn't define it throws */
+        $this->assertEquals($timestamp, $exception->getTimestamp(), "Timestamp retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for UnsupportedReferenceTimeException::getTimestamp().
+     *
+     * @return \Generator
+     * @noinspection PhpDocMissingThrowsInspection DateTime constructor should not throw with a timestamp argument.
+     */
+    public function dataForTestGetTimestamp(): Generator
+    {
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with a timestamp argument. */
+        yield from [
+            "typicalTimestamp60" => [60, 60,],
+            "extremeVeryEarly" => [self::MinTimestamp, self::MinTimestamp,],
+            "extremeVeryLate" => [self::MaxTimestamp, self::MaxTimestamp,],
+            "typicalDateTime60" => [new DateTime("@60", new DateTimeZone("UTC")), 60,],
+            "extremeDateTimeVeryEarly" => [new DateTime("@" . self::MinTimestamp, new DateTimeZone("UTC")), self::MinTimestamp,],
+            "extremeDateTimeVeryLate" => [new DateTime("@" . self::MaxTimestamp, new DateTimeZone("UTC")), self::MaxTimestamp,],
+        ];
+
+        $nowTimestamp = time();
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with a timestamp argument. */
+        $nowTime = new DateTime("@{$nowTimestamp}", new DateTimeZone("UTC"));
+        yield "typicalNow" => [$nowTimestamp, $nowTimestamp,];
+        yield "typicalDateTimeNow" => [$nowTime, $nowTimestamp,];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            do {
+                $timestamp = mt_rand(-60 * 365 * 24 * 60 * 60, 60 * 365 * 24 * 60 * 60);
+            } while (0 === $timestamp);
+
+            /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with a timestamp argument. */
+            $time = new DateTime("@{$timestamp}", new DateTimeZone("UTC"));
+
+            yield "randomTimestamp" . sprintf("%02d", $idx) => [$timestamp, $timestamp,];
+            yield "randomDateTime" . sprintf("%02d", $idx) => [$time, $timestamp,];
+        }
+    }
+
+    /**
+     * Test the UnsupportedReferenceTimeException::getTimestamp() method.
+     *
+     * @dataProvider dataForTestGetTimestamp
+     *
+     * @param int|\DateTime $time The time to use to initialise the test exception.
+     * @param int $expectedTimestamp The expected value returned from getTimestamp().
+     */
+    public function testGetTimestamp(int|DateTime $time, int $expectedTimestamp): void
+    {
+        $exception = new UnsupportedReferenceTimeException($time);
+        $this->assertEquals($expectedTimestamp, $exception->getTimestamp(), "Unsupported reference timestamp retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for UnsupportedReferenceTimeException::getTimestamp().
+     *
+     * @return \Generator
+     * @noinspection PhpDocMissingThrowsInspection DateTime constructor should not throw with a timestamp argument.
+     */
+    public function dataForTestGetTime(): Generator
+    {
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with a timestamp argument. */
+        yield from [
+            "typicalTimestamp60" => [60, new DateTime("@60", new DateTimeZone("UTC")),],
+            "extremeVeryEarly" => [self::MinTimestamp, new DateTime("@" . self::MinTimestamp, new DateTimeZone("UTC")),],
+            "extremeVeryLate" => [self::MaxTimestamp, new DateTime("@" . self::MaxTimestamp, new DateTimeZone("UTC")),],
+            "typicalDateTime60" => [new DateTime("@60", new DateTimeZone("UTC")), new DateTime("@60", new DateTimeZone("UTC")),],
+            "extremeDateTimeVeryEarly" => [new DateTime("@" . self::MinTimestamp, new DateTimeZone("UTC")), new DateTime("@" . self::MinTimestamp, new DateTimeZone("UTC")),],
+            "extremeDateTimeVeryLate" => [new DateTime("@" . self::MaxTimestamp, new DateTimeZone("UTC")), new DateTime("@" . self::MaxTimestamp, new DateTimeZone("UTC")),],
+        ];
+
+        $nowTimestamp = time();
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with a timestamp argument. */
+        $nowTime = new DateTime("@{$nowTimestamp}", new DateTimeZone("UTC"));
+        yield "typicalNow" => [$nowTimestamp, $nowTime,];
+        yield "typicalDateTimeNow" => [$nowTime, $nowTime,];
+
+        for ($idx = 0; $idx < 100; ++$idx) {
+            do {
+                $timestamp = mt_rand(self::MinTimestamp, self::MaxTimestamp);
+            } while (0 === $timestamp);
+
+            /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with a timestamp argument. */
+            $time = new DateTime("@{$timestamp}", new DateTimeZone("UTC"));
+
+            yield "randomTimestamp" . sprintf("%02d", $idx) => [$timestamp, $time,];
+            yield "randomDateTime" . sprintf("%02d", $idx) => [$time, $time,];
+        }
+    }
+
+    /**
+     * Test the UnsupportedReferenceTimeException::getTime() method.
+     *
+     * @dataProvider dataForTestGetTime
+     *
+     * @param int|\DateTime $time The time to use to initialise the test exception.
+     * @param \DateTime $expectedTime The expected value returned from getDateTime().
+     */
+    public function testGetTime(int|DateTime $time, DateTime $expectedTime): void
+    {
+        $exception = new UnsupportedReferenceTimeException($time);
+        $this->assertEquals($expectedTime, $exception->getTime(), "Unsupported DateTime retrieved from exception was not as expected.");
+    }
+}

--- a/tests/Exceptions/UrlGenerator/UnsupportedRendererExceptionTest.php
+++ b/tests/Exceptions/UrlGenerator/UnsupportedRendererExceptionTest.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * Copyright 2022 Darren Edale
+ *
+ * This file is part of the php-totp package.
+ *
+ * php-totp is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License v2.0.
+ *
+ * php-totp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License v2.0
+ * along with php-totp. If not, see <http://www.apache.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Equit\Totp\Tests\Exceptions\UrlGenerator;
+
+use Equit\Totp\Exceptions\UrlGenerator\UnsupportedRendererException;
+use Equit\Totp\Renderers\EightDigits;
+use Equit\Totp\Renderers\Integer;
+use Equit\Totp\Renderers\Renderer;
+use Equit\Totp\Renderers\SixDigits;
+use Equit\Totp\Tests\Framework\TestCase;
+use Exception;
+use Generator;
+use TypeError;
+
+/**
+ * Unit test for the UnsupportedRendererException class.
+ */
+class UnsupportedRendererExceptionTest extends TestCase
+{
+    /**
+     * Create an anonymous unsupported Renderer instance.
+     *
+     * @return \Equit\Totp\Renderers\Renderer The generated renderer.
+     */
+    private static function createUnsupportedRenderer(): Renderer
+    {
+        return new class implements Renderer
+        {
+            public function render(string $hmac): string
+            {
+                return "fizzbuzz";
+            }
+        };
+    }
+
+    /**
+     * Test data for UnsupportedRendererException constructor.
+     *
+     * @return array The test data.
+     */
+    public function dataForTestConstructor(): array
+    {
+        return [
+            "typicalRendererOnly" => [self::createUnsupportedRenderer(),],
+            "typicalRendererAndMessage" => [self::createUnsupportedRenderer(), "This is not a supported renderer.",],
+            "typicalRendererMessageAndCode" => [self::createUnsupportedRenderer(), "This is not a supported renderer.", 12,],
+            "typicalRendererMessageCodeAndPrevious" => [self::createUnsupportedRenderer(), "This is not a supported renderer.", 12, new Exception("foo"),],
+            "invalidStringRenderer" => [Integer::class, "class-string is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+            "invalidNullRenderer" => [null, "null is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+            "invalidStringableRenderer" => [self::createStringable(""), "'' is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+            "invalidIntRenderer" => [1, "1 is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+            "invalidFloatRenderer" => [1.115, "1.115 is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+            "invalidTrueRenderer" => [true, "true is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+            "invalidFalseRenderer" => [false, "false is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+            "invalidArrayRenderer" => [["render" => fn(string $hmac): string => "",], "array is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+            "invalidObjectRenderer" => [(object)["render" => fn(string $hmac): string => "",], "object is not a supported renderer.", 12, new Exception("foo"), TypeError::class],
+        ];
+    }
+
+    /**
+     * Test for UnsupportedRendererException constructor.
+     *
+     * @dataProvider dataForTestConstructor
+     *
+     * @param mixed $renderer The invalid Renderer instance for the test exception.
+     * @param mixed $message The message for the test exception. Defaults to an empty string.
+     * @param mixed $code The error code for the test exception. Defaults to 0.
+     * @param mixed|null $previous The previous throwable for the test exception. Defaults to null.
+     * @param string|null $exceptionClass The class name of the exception that is expected during the test, if any.
+     */
+    public function testConstructor(mixed $renderer, mixed $message = "", mixed $code = 0, mixed $previous = null, string $exceptionClass = null): void
+    {
+        if (isset($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $exception = new UnsupportedRendererException($renderer, $message, $code, $previous);
+        $this->assertSame($renderer, $exception->getRenderer(), "Unsupported Renderer retrieved from exception was not as expected.");
+        $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
+        $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
+        $this->assertSame($previous, $exception->getPrevious(), "Previous throwable retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for UnsupportedRendererException::getRenderer().
+     *
+     * @return array
+     * @noinspection PhpDocMissingThrowsInspection Integer renderer constructor guaranteed not to throw here.
+     */
+    public function dataForTestGetRenderer(): array
+    {
+        /** @noinspection PhpUnhandledExceptionInspection Integer renderer constructor guaranteed not to throw here. */
+        return [
+            [new Integer(7),],
+            [new SixDigits(),],
+            [new EightDigits(),],
+            [self::createUnsupportedRenderer(),],
+        ];
+    }
+
+    /**
+     * Test the UnsupportedRendererException::getRenderer() method.
+     *
+     * @dataProvider dataForTestGetRenderer
+     *
+     * @param Renderer $renderer The Renderer to test with.
+     */
+    public function testGetRenderer(Renderer $renderer): void
+    {
+        $exception = new UnsupportedRendererException($renderer);
+        $this->assertSame($renderer, $exception->getRenderer(), "Unsupported renderer retrieved from exception was not as expected.");
+    }
+
+    /**
+     * Test data for UnsupportedRendererException::getRendererClass().
+     *
+     * @return array The test data.
+     * @noinspection PhpDocMissingThrowsInspection Integer renderer constructor guaranteed not to throw.
+     */
+    public function dataForTestGetRendererClass(): array
+    {
+        /** @noinspection PhpUnhandledExceptionInspection Renderer constructor guaranteed not to throw here */
+        return [
+            [new Integer(7), Integer::class,],
+            [new SixDigits(), SixDigits::class,],
+            [new EightDigits(), EightDigits::class,],
+        ];
+    }
+
+    /**
+     * Test the UnsupportedRendererException::getRendererClass() method.
+     *
+     * @dataProvider dataForTestGetRendererClass
+     *
+     * @param Renderer $renderer The Renderer to test with.
+     * @param class-string $class The expected renderer class name.
+     */
+    public function testGetRendererClass(Renderer $renderer, string $class): void
+    {
+        $exception = new UnsupportedRendererException($renderer);
+        $this->assertEquals($class, $exception->getRendererClass(), "Unsupported renderer class retrieved from exception was not as expected.");
+    }
+}


### PR DESCRIPTION
- New test cases:
  - InvalidBase32DataExceptionTest
  - InvalidBase64DataExceptionTest
  - InvalidDigitsExceptionTest
  - InvalidHashAlgorithmExceptionTest
  - InvalidIntervalExceptionTest
  - InvalidSecretExceptionTest
  - InvalidTimeExceptionTest
  - InvalidUserExceptionTest
  - InvalidVerificationWindowExceptionTest
  - UnsupportedReferenceTimeExceptionTest
  - UnsupportedRendererException

- fixed inconsistent naming of getAlgorithm() method in InvalidHashAlgorithmException
- fixed inconsitent naming of rendererClass() method in UnsupportedRendererException