### PR TITLE
PT-10 - PT-10-review-symbol-names-and-argument-types-for-consistency

### DIFF
--- a/src/Base32.php
+++ b/src/Base32.php
@@ -73,7 +73,7 @@ class Base32
      *
      * @param string $data The raw data to encode.
      */
-    public function setRaw(string $data)
+    public function setRaw(string $data): void
     {
         $this->m_rawData     = $data;
         $this->m_encodedData = null;
@@ -88,7 +88,7 @@ class Base32
      *
      * @throws InvalidBase32DataException
      */
-    public function setEncoded(string $base32)
+    public function setEncoded(string $base32): void
     {
         $length = strlen($base32);
 
@@ -186,7 +186,7 @@ class Base32
      *
      * This is called when the raw content is requested and the internal cache of the raw content is out of sync.
      */
-    protected function decodeBase32Data()
+    protected function decodeBase32Data(): void
     {
         $byteSequence    = strtoupper($this->m_encodedData);
         $this->m_rawData = "";
@@ -245,7 +245,7 @@ class Base32
      * This is called when the encoded content is requested and the internal cache of the encoded content is out of
      * sync.
      */
-    protected function encodeRawData()
+    protected function encodeRawData(): void
     {
         $this->m_encodedData = "";
         $len                 = strlen($this->m_rawData);

--- a/src/Base64.php
+++ b/src/Base64.php
@@ -68,7 +68,7 @@ class Base64
      *
      * @param string $rawData The raw data to encode.
      */
-    public function setRaw(string $rawData)
+    public function setRaw(string $rawData): void
     {
         $this->m_rawData     = $rawData;
         $this->m_encodedData = null;
@@ -83,7 +83,7 @@ class Base64
      *
      * @throws InvalidBase64DataException
      */
-    public function setEncoded(string $base64)
+    public function setEncoded(string $base64): void
     {
         // note base64_decode() is too tolerant of invalid data so we roll our own validation instead of relying on
         // false being returned from base64_decode()
@@ -110,7 +110,7 @@ class Base64
                 throw new InvalidBase64DataException($base64, "Base64 data must be padded with either 0, 1 or 2 '=' characters.");
         }
 
-        // ensure all non-padding characters are from the Base32 dictionary
+        // ensure all non-padding characters are from the Base64 dictionary
         $validLength = strspn($base64, self::Dictionary, 0, $length);
 
         if ($length !== $validLength) {
@@ -183,7 +183,7 @@ class Base64
      *
      * This is called when the raw content is requested and the internal cache of the raw content is out of sync.
      */
-    protected function decodeBase64Data()
+    protected function decodeBase64Data(): void
     {
         $this->m_rawData = base64_decode($this->m_encodedData);
     }
@@ -194,7 +194,7 @@ class Base64
      * This is called when the encoded content is requested and the internal cache of the encoded content is out of
      * sync.
      */
-    protected function encodeRawData()
+    protected function encodeRawData(): void
     {
         $this->m_encodedData = base64_encode($this->m_rawData);
     }

--- a/src/Exceptions/InvalidHashAlgorithmException.php
+++ b/src/Exceptions/InvalidHashAlgorithmException.php
@@ -28,23 +28,23 @@ use Throwable;
 class InvalidHashAlgorithmException extends TotpException
 {
     /**
-     * @var string The invalid algorithm name.
+     * @var string The invalid hash algorithm name.
      */
-    private string $m_algorithm;
+    private string $m_hashAlgorithm;
 
     /**
      * Initialise a new InvalidHashAlgorithmException.
      *
-     * @param string $algorithm The invalid algorithm nane.
+     * @param string $hashAlgorithm The invalid hash algorithm nane.
      * @param string $message An optional message explaining why it's invalid. Defaults to an empty string.
      * @param int $code An optional code for the error. Defaults to 0.
      * @param \Throwable|null $previous An optional previous Throwable that was thrown immediately before this. Defaults
      * to null.
      */
-    public function __construct(string $algorithm, string $message = "", int $code = 0, ?Throwable $previous = null)
+    public function __construct(string $hashAlgorithm, string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
-        $this->m_algorithm = $algorithm;
+        $this->m_hashAlgorithm = $hashAlgorithm;
     }
 
     /**
@@ -54,6 +54,6 @@ class InvalidHashAlgorithmException extends TotpException
      */
     public function getHashAlgorithm(): string
     {
-        return $this->m_algorithm;
+        return $this->m_hashAlgorithm;
     }
 }

--- a/src/Exceptions/InvalidSecretException.php
+++ b/src/Exceptions/InvalidSecretException.php
@@ -27,6 +27,9 @@ use Throwable;
  */
 class InvalidSecretException extends TotpException
 {
+    /**
+     * @var string The invalid secret.
+     */
     private string $m_secret;
 
     /**

--- a/src/Exceptions/SecureRandomDataUnavailableException.php
+++ b/src/Exceptions/SecureRandomDataUnavailableException.php
@@ -20,6 +20,9 @@ declare(strict_types=1);
 
 namespace Equit\Totp\Exceptions;
 
+/**
+ * Exception thrown when the Totp class is unable to generate cryptographically-secure random secrets.
+ */
 class SecureRandomDataUnavailableException extends TotpException
 {
 }

--- a/src/Exceptions/TotpException.php
+++ b/src/Exceptions/TotpException.php
@@ -23,7 +23,7 @@ namespace Equit\Totp\Exceptions;
 use Exception;
 
 /**
- * Base class for all exceptions related to TOTP instances.
+ * Base class for all exceptions related to Totp instances.
  */
 class TotpException extends Exception
 {

--- a/src/Exceptions/UrlGenerator/UnsupportedReferenceTimeException.php
+++ b/src/Exceptions/UrlGenerator/UnsupportedReferenceTimeException.php
@@ -44,24 +44,21 @@ class UnsupportedReferenceTimeException extends UrlGeneratorException
     /**
      * Initialise a new exception instance.
      *
-     * @param int | DateTime $time The unsupported timestamp.
+     * @param DateTime | int $time The unsupported timestamp.
      * @param string $message An optional message explaining why it's unsupported. Defaults to an empty string.
      * @param int $code An optional error code. Defaults to 0.
      * @param Throwable|null $previous An optional previous Throwable that was thrown. Defaults to null.
      *
      * @noinspection PhpDocMissingThrowsInspection DateTime constructor guaranteed not to throw here.
      */
-    public function __construct(int|DateTime $time, string $message = "", int $code = 0, ?Throwable $previous = null)
+    public function __construct(DateTime|int $time, string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 
         if ($time instanceof DateTime) {
-            $this->m_time      = $time;
-            $this->m_timestamp = $time->getTimestamp();
+            $this->m_time = $time;
         } else {
             $this->m_timestamp = $time;
-            /** @noinspection PhpUnhandledExceptionInspection DateTime constructor will not throw here */
-            $this->m_time = new DateTime("@{$time}", new DateTimeZone("UTC"));
         }
     }
 
@@ -72,6 +69,10 @@ class UnsupportedReferenceTimeException extends UrlGeneratorException
      */
     public function getTimestamp(): int
     {
+        if (!isset($this->m_timestamp)) {
+            $this->m_timestamp = $this->m_time->getTimestamp();
+        }
+
         return $this->m_timestamp;
     }
 
@@ -79,9 +80,15 @@ class UnsupportedReferenceTimeException extends UrlGeneratorException
      * Fetch the unsupported time.
      *
      * @return DateTime The time.
+     * @noinspection PhpDocMissingThrowsInspection DateTime constructor won't throw with timestamp argument.
      */
     public function getTime(): DateTime
     {
+        if (!isset($this->m_time)) {
+            /** @noinspection PhpUnhandledExceptionInspection DateTime constructor won't throw with timestamp argument. */
+            $this->m_time = new DateTime("@{$this->m_timestamp}", new DateTimeZone("UTC"));
+        }
+
         return $this->m_time;
     }
 }

--- a/src/Exceptions/UrlGenerator/UnsupportedRendererException.php
+++ b/src/Exceptions/UrlGenerator/UnsupportedRendererException.php
@@ -32,13 +32,13 @@ use Throwable;
 class UnsupportedRendererException extends UrlGeneratorException
 {
     /**
-     * @var Renderer The invalid renderer.
+     * @var Renderer The unsupported renderer.
      */
     private Renderer $m_renderer;
 
     /**
-     * @param \Equit\Totp\Renderers\Renderer $renderer The invalid renderer.
-     * @param string $message An optional description of why it's invalid. Defaults to an empty string.
+     * @param \Equit\Totp\Renderers\Renderer $renderer The unsupported renderer.
+     * @param string $message An optional description of why it's unsuported. Defaults to an empty string.
      * @param int $code An optional error code. Defaults to 0.
      * @param Throwable|null $previous An optional previous Throwable. Defaults to null.
      */
@@ -49,9 +49,9 @@ class UnsupportedRendererException extends UrlGeneratorException
     }
 
     /**
-     * Fetch the invalid renderer.
+     * Fetch the unsupported renderer.
      *
-     * @return \Equit\Totp\Renderers\Renderer The invalid renderer.
+     * @return \Equit\Totp\Renderers\Renderer The unsupported renderer.
      */
     public function getRenderer(): Renderer
     {
@@ -59,7 +59,7 @@ class UnsupportedRendererException extends UrlGeneratorException
     }
 
     /**
-     * Convenience method to get the class name of the invalid renderer.
+     * Convenience method to get the class name of the unsupported renderer.
      *
      * @return string The renderer class name.
      */

--- a/src/Renderers/EightDigits.php
+++ b/src/Renderers/EightDigits.php
@@ -22,6 +22,10 @@ namespace Equit\Totp\Renderers;
 
 /**
  * Render a TOTP of eight decimal digits.
+ *
+ * The standard procedure, described in RFC 6238, is used to extract a 31-bit integer from the HOTP HMAC, the lease-
+ * significant 8 digits of which are used as the password. The password is padded to the left with 0s if it has fewer
+ * than 8 digits.
  */
 class EightDigits implements IntegerRenderer
 {

--- a/src/Renderers/ExtractsStandard31BitInteger.php
+++ b/src/Renderers/ExtractsStandard31BitInteger.php
@@ -41,7 +41,7 @@ trait ExtractsStandard31BitInteger
      *
      * @return int The extracted int.
      */
-    protected static function extractIntFromHmac(string $hmac): int
+    protected static function extractIntegerFromHmac(string $hmac): int
     {
         $offset = ord($hmac[strlen($hmac) - 1]) & 0xf;
 

--- a/src/Renderers/Integer.php
+++ b/src/Renderers/Integer.php
@@ -31,6 +31,8 @@ use Equit\Totp\Exceptions\InvalidDigitsException;
  */
 class Integer implements IntegerRenderer
 {
+    use RendersStandardIntegerPasswords;
+
     /**
      * The minimum number of digits, as per RFC 6238.
      */
@@ -40,8 +42,6 @@ class Integer implements IntegerRenderer
      * The default number of digits.
      */
     public const DefaultDigits = 6;
-
-    use RendersStandardIntegerPasswords;
 
     /**
      * @var int The number of digits.

--- a/src/Renderers/RendersStandardIntegerPasswords.php
+++ b/src/Renderers/RendersStandardIntegerPasswords.php
@@ -55,7 +55,7 @@ trait RendersStandardIntegerPasswords
     public function render(string $hmac): string
     {
         assert(5 < $this->digits(), "Invalid digit count in Renderer subclass " . get_class($this));
-        $password = self::extractIntFromHmac($hmac) % (10 ** $this->digits());
+        $password = self::extractIntegerFromHmac($hmac) % (10 ** $this->digits());
         return str_pad("{$password}", $this->digits(), "0", STR_PAD_LEFT);
     }
 }

--- a/src/Renderers/SixDigits.php
+++ b/src/Renderers/SixDigits.php
@@ -22,6 +22,10 @@ namespace Equit\Totp\Renderers;
 
 /**
  * Render a TOTP of six decimal digits.
+ *
+ * The standard procedure, described in RFC 6238, is used to extract a 31-bit integer from the HOTP HMAC, the lease-
+ * significant 6 digits of which are used as the password. The password is padded to the left with 0s if it has fewer
+ * than 6 digits.
  */
 class SixDigits implements IntegerRenderer
 {

--- a/src/Renderers/Steam.php
+++ b/src/Renderers/Steam.php
@@ -44,8 +44,8 @@ class Steam implements Renderer
 	 */
 	public function render(string $hmac): string
 	{
-        $passwordValue = self::extractIntFromHmac($hmac);
-		$password = "";
+        $passwordValue = self::extractIntegerFromHmac($hmac);
+        $password      = "";
 
         // algorithm ported from PIP package steam-totp (https://pypi.org/project/steam-totp/)
 		for ($i = 0; $i < self::CharacterCount; ++$i) {

--- a/src/Totp.php
+++ b/src/Totp.php
@@ -135,7 +135,7 @@ class Totp
      */
     public function __construct(TotpSecret|string $secret = null, Renderer $renderer = null, int $timeStep = self::DefaultTimeStep, int|DateTime $referenceTime = self::DefaultReferenceTime, string $hashAlgorithm = self::DefaultAlgorithm)
     {
-        $this->setSecret($secret ?? self::randomSecret());
+        $this->setSecret($secret ?? static::randomSecret());
         $this->setRenderer($renderer ?? static::defaultRenderer());
         $this->setTimeStep($timeStep);
         $this->setHashAlgorithm($hashAlgorithm);
@@ -289,19 +289,19 @@ class Totp
     }
 
     /**
-     * Set the algorithm to use when generating HMACs.
+     * Set the hash algorithm to use when generating HMACs.
      *
-     * The algorithm must be one of SHA1, SHA256 or SHA512. Use the class constants for these to avoid errors.
+     * The hash algorithm must be one of SHA1, SHA256 or SHA512. Use the class constants for these to avoid errors.
      *
-     * @param string $algorithm The algorithm.
+     * @param string $hashAlgorithm The hash algorithm.
      *
-     * @throws InvalidHashAlgorithmException if the algorithm provided is not valid.
+     * @throws InvalidHashAlgorithmException if the hash algorithm provided is not valid.
      */
-    public function setHashAlgorithm(string $algorithm): void
+    public function setHashAlgorithm(string $hashAlgorithm): void
     {
-        $this->m_hashAlgorithm = match ($algorithm) {
-            self::Sha1Algorithm, self::Sha256Algorithm, self::Sha512Algorithm => $algorithm,
-            default => throw new InvalidHashAlgorithmException($algorithm, "The hash algorithm must be one of " . self::Sha1Algorithm . ", " . self::Sha256Algorithm . " or " . self::Sha512Algorithm . "."),
+        $this->m_hashAlgorithm = match ($hashAlgorithm) {
+            self::Sha1Algorithm, self::Sha256Algorithm, self::Sha512Algorithm => $hashAlgorithm,
+            default => throw new InvalidHashAlgorithmException($hashAlgorithm, "The hash algorithm must be one of " . self::Sha1Algorithm . ", " . self::Sha256Algorithm . " or " . self::Sha512Algorithm . "."),
         };
     }
 
@@ -417,10 +417,12 @@ class Totp
      * The reference time from which time steps are measured as a DateTime object.
      *
      * @return \DateTime The reference time.
+     * @noinspection PhpDocMissingThrowsInspection DateTime constructor doesn't throw with Unix timestamp.
      */
-    public function referenceDateTime(): DateTime
+    public function referenceTime(): DateTime
     {
-        return DateTime::createFromFormat("U", "{$this->m_referenceTime}", new DateTimeZone("UTC"));
+        /** @noinspection PhpUnhandledExceptionInspection DateTime constructor doesn't throw with Unix timestamp. */
+        return new DateTime("@{$this->m_referenceTime}", new DateTimeZone("UTC"));
     }
 
     /**
@@ -544,7 +546,7 @@ class Totp
      * @return string The HMAC at the current system time.
      * @throws InvalidTimeException if the current time is before the reference time.
      */
-    public final function currentHmac(): string
+    public final function hmac(): string
     {
         return $this->hmacAt(self::currentTime());
     }
@@ -568,7 +570,7 @@ class Totp
      * @return string The current TOTP password.
      * @throws InvalidTimeException if the current time is before the reference time.
      */
-    public final function currentPassword(): string
+    public final function password(): string
     {
         return $this->passwordAt(self::currentTime());
     }

--- a/src/TotpSecret.php
+++ b/src/TotpSecret.php
@@ -42,11 +42,9 @@ use Equit\Totp\Exceptions\InvalidSecretException;
 final class TotpSecret
 {
     /**
-     * @var string|null The raw bytes of the secret.
-     *
-     * Will be null if the secret was initialised as Base32 or Base64 and raw() has yet to be called.
+     * @var string The raw bytes of the secret.
      */
-    private ?string $m_raw;
+    private string $m_raw;
 
     /**
      * @var string|null The Base32 encoding of the secret.

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -34,7 +34,7 @@ use Equit\Totp\Renderers\IntegerRenderer;
  *
  *     otpauth://totp/[{issuer}:]{user}/?secret={secret}[&digits={digits}][&algorithm={algorithm}][&period={period}]
  *
- * The {issuer} (setIssuer(), issuer()) is optional; the {user} (setUser(), user()) is mandatory. By default the
+ * The {issuer} (setIssuer(), issuer()) is optional; the {user} (setUser(), user()) is mandatory. By default, the
  * generator will generate the URL parameters for digits, algorithm and period if those properties of the provided Totp
  * instance are non-default (e.g. if the algorithm is SHA1 the algorithm won't be part of the URL, but if it's SHA256 it
  * will). You can force or suppress individual parameters by passing `true` or `false` respectively to
@@ -43,8 +43,8 @@ use Equit\Totp\Renderers\IntegerRenderer;
  *
  * ## Static/fluent interface
  *
- * Each of these methods can be called statically to create a UrlGenerator. You can also chain them to fluently
- * construct a UrlGenerator with the required feature set. For example:
+ * Each of these methods can be called statically to create a UrlGenerator. You can also chain them to construct a
+ * UrlGenerator fluently with the required feature set. For example:
  *
  *     $generator = UrlGenerator::for("darren")->from("Equit")->withDigits();
  *
@@ -54,7 +54,7 @@ use Equit\Totp\Renderers\IntegerRenderer;
  *
  * are both valid, and will produce UrlGenerators with the same features.
  *
- * @method static self for(string $user) Initialise a generator for a given user.
+ * @method static self for (string $user) Initialise a generator for a given user.
  * @method static self from(string|null $issuer) Initialise a generator from a given issuer.
  * @method static self withPeriod() Initialise a generator that includes the period parameter in URLs it generates.
  * @method static self withPeriodIfCustomised() Initialise a generator that includes the period parameter in URLs it
@@ -332,6 +332,8 @@ class UrlGenerator
             $url .= "&issuer=" . urlencode($this->issuer());
         }
 
+        /** @noinspection PhpPossiblePolymorphicInvocationInspection digits() is only called after checking we have on
+         * instance of IntegerRenderer */
         if (true === $this->includesDigits() || (is_null($this->includesDigits()) && $totp->renderer() instanceof IntegerRenderer && Integer::DefaultDigits !== $totp->renderer()->digits())) {
             $url .= "&digits={$totp->renderer()->digits()}";
         }
@@ -445,6 +447,7 @@ class UrlGenerator
      * @param array $args The arguments provided in the call.
      *
      * @return $this
+     * @throws \Equit\Totp\Exceptions\UrlGenerator\InvalidUserException if for() is called with an empty user.
      */
     public function __call(string $method, array $args): self
     {
@@ -516,6 +519,7 @@ class UrlGenerator
      * @param array $args The arguments provided in the call.
      *
      * @return static
+     * @throws \Equit\Totp\Exceptions\UrlGenerator\InvalidUserException if for() is called with an empty user.
      */
     public static function __callStatic(string $method, array $args): static
     {

--- a/tests/Exceptions/InvalidTimeExceptionTest.php
+++ b/tests/Exceptions/InvalidTimeExceptionTest.php
@@ -82,7 +82,7 @@ class InvalidTimeExceptionTest extends TestCase
         /** @noinspection PhpUnhandledExceptionInspection DateTime constructor should not throw with timestamp argument. */
         $time = new DateTime("@{$timestamp}", new DateTimeZone("UTC"));
 
-        $this->assertEquals($time, $exception->getDateTime(), "DateTime retrieved from exception was not as expected.");
+        $this->assertEquals($time, $exception->getTime(), "DateTime retrieved from exception was not as expected.");
         $this->assertEquals($timestamp, $exception->getTimestamp(), "Timestamp retrieved from exception was not as expected.");
         $this->assertEquals($message, $exception->getMessage(), "Message retrieved from exception was not as expected.");
         $this->assertEquals($code, $exception->getCode(), "Error code retrieved from exception was not as expected.");
@@ -156,6 +156,6 @@ class InvalidTimeExceptionTest extends TestCase
     public function testGetDateTime(int $timestamp, DateTime $expectedTime): void
     {
         $exception = new InvalidTimeException($timestamp);
-        $this->assertEquals($expectedTime, $exception->getDateTime(), "Invalid DateTime retrieved from exception was not as expected.");
+        $this->assertEquals($expectedTime, $exception->getTime(), "Invalid DateTime retrieved from exception was not as expected.");
     }
 }

--- a/tests/TotpTest.php
+++ b/tests/TotpTest.php
@@ -664,7 +664,7 @@ class TotpTest extends TestCase
                 [
                     "secret" => $secret,
                     "timeStep" => $timeStep,
-                    "referenceDateTime" => $referenceTime,
+                    "referenceTime" => $referenceTime,
                 ],
             ];
         }
@@ -900,7 +900,7 @@ class TotpTest extends TestCase
      * @param string|null $exceptionClass
      *
      * @noinspection PhpDocMissingThrowsInspection Totp::sixDigits() should only throw expected test exceptions.
-     * DateTime constructor and Totp::currentPassword() should not throw with test data.
+     * DateTime constructor and Totp::password() should not throw with test data.
      */
     public function testSixDigits(string $secret, int $timeStep = Totp::DefaultTimeStep, int|DateTime $referenceTime = Totp::DefaultReferenceTime, string $hashAlgorithm = Totp::DefaultAlgorithm, array $expectations = [], string $exceptionClass = null): void
     {
@@ -925,11 +925,11 @@ class TotpTest extends TestCase
         $this->assertInstanceOf(SixDigits::class, $totp->renderer(), "The Totp does not have the expected renderer type.");
         /** @noinspection PhpPossiblePolymorphicInvocationInspection Guaranteed to be an instance of IntegerRenderer */
         $this->assertEquals(6, $totp->renderer()->digits(), "The Totp renderer does not use the expected number of digits.");
-        $this->assertEquals($referenceTime, $totp->referenceDateTime(), "Reference DateTime in Totp object does not match expected DateTime.");
+        $this->assertEquals($referenceTime, $totp->referenceTime(), "Reference DateTime in Totp object does not match expected DateTime.");
         $this->assertEquals($referenceTimestamp, $totp->referenceTimestamp(), "Reference timestamp in Totp object does not match expected timestamp.");
 
-        /** @noinspection PhpUnhandledExceptionInspection currentPassword should not throw with test data. */
-        $password = $totp->currentPassword();
+        /** @noinspection PhpUnhandledExceptionInspection password should not throw with test data. */
+        $password = $totp->password();
         $this->assertEquals(6, strlen($password), "Password from Totp object is not 6 digits.");
         $this->assertStringContainsOnly("0123456789", $password, "Password contains some invalid content.");
 
@@ -1041,7 +1041,7 @@ class TotpTest extends TestCase
      * provide in the method call; the value element is the expected return value.
      *
      * @noinspection PhpDocMissingThrowsInspection Totp::eightDigits() should only throw expected test exceptions.
-     * DateTime constructor and Totp::currentPassword() should not throw with test data.
+     * DateTime constructor and Totp::password() should not throw with test data.
      */
     public function testEightDigits(string $secret, int $timeStep = Totp::DefaultTimeStep, int|DateTime $referenceTime = Totp::DefaultReferenceTime, string $hashAlgorithm = Totp::DefaultAlgorithm, array $expectations = [], string $exceptionClass = null): void
     {
@@ -1066,11 +1066,11 @@ class TotpTest extends TestCase
         $this->assertInstanceOf(EightDigits::class, $totp->renderer(), "The Totp does not have the expected renderer type.");
         /** @noinspection PhpPossiblePolymorphicInvocationInspection Guaranteed to be an instance of IntegerRenderer */
         $this->assertEquals(8, $totp->renderer()->digits(), "The Totp renderer does not use the expected number of digits.");
-        $this->assertEquals($referenceTime, $totp->referenceDateTime(), "Reference DateTime in Totp object does not match expected DateTime.");
+        $this->assertEquals($referenceTime, $totp->referenceTime(), "Reference DateTime in Totp object does not match expected DateTime.");
         $this->assertEquals($referenceTimestamp, $totp->referenceTimestamp(), "Reference timestamp in Totp object does not match expected timestamp.");
 
-        /** @noinspection PhpUnhandledExceptionInspection currentPassword() should not throw with test data. */
-        $password = $totp->currentPassword();
+        /** @noinspection PhpUnhandledExceptionInspection password() should not throw with test data. */
+        $password = $totp->password();
         $this->assertEquals(8, strlen($password), "Password from Totp object is not 8 digits.");
         $this->assertStringContainsOnly("0123456789", $password, "Password contains some invalid content.");
 
@@ -1307,7 +1307,7 @@ class TotpTest extends TestCase
      * provide in the method call; the value element is the expected return value.
      *
      * @noinspection PhpDocMissingThrowsInspection Totp::integer() should only throw expected test exceptions. DateTime
-     * constructor and Totp::currentPassword() should not throw with test data.
+     * constructor and Totp::password() should not throw with test data.
      */
     public function testInteger(mixed $digits, string $secret, int $timeStep = Totp::DefaultTimeStep, int|DateTime $referenceTime = Totp::DefaultReferenceTime, string $hashAlgorithm = Totp::DefaultAlgorithm, array $expectations = [], string $exceptionClass = null): void
     {
@@ -1332,11 +1332,11 @@ class TotpTest extends TestCase
         $this->assertInstanceOf(Integer::class, $totp->renderer(), "The Totp does not have the expected renderer type.");
         /** @noinspection PhpPossiblePolymorphicInvocationInspection Guaranteed to be an instance of IntegerRenderer */
         $this->assertEquals($digits, $totp->renderer()->digits(), "The Totp renderer does not use the expected number of digits.");
-        $this->assertEquals($referenceTime, $totp->referenceDateTime(), "Reference DateTime in Totp object does not match expected DateTime.");
+        $this->assertEquals($referenceTime, $totp->referenceTime(), "Reference DateTime in Totp object does not match expected DateTime.");
         $this->assertEquals($referenceTimestamp, $totp->referenceTimestamp(), "Reference timestamp in Totp object does not match expected timestamp.");
 
-        /** @noinspection PhpUnhandledExceptionInspection currentPassword() should not throw with test data. */
-        $password = $totp->currentPassword();
+        /** @noinspection PhpUnhandledExceptionInspection password() should not throw with test data. */
+        $password = $totp->password();
         $this->assertEquals($digits, strlen($password), "Password from Totp object is not {$digits} digits.");
         $this->assertStringContainsOnly("0123456789", $password, "Password contains some invalid content.");
 
@@ -1687,11 +1687,9 @@ class TotpTest extends TestCase
 
         if (is_int($time)) {
             $this->assertSame($time, $totp->referenceTimestamp());
-        } else {
-            if ($time instanceof DateTime) {
-                $this->assertInstanceOf(DateTime::class, $totp->referenceDateTime(), "referenceDateTime() failed to return a DateTime object with input DateTime '" . $time->format("Y-m-d H:i:s") . "'");
-                $this->assertEquals($time, $totp->referenceDateTime());
-            }
+        } else if ($time instanceof DateTime) {
+            $this->assertInstanceOf(DateTime::class, $totp->referenceTime(), "referenceTime() failed to return a DateTime object with input DateTime '" . $time->format("Y-m-d H:i:s") . "'");
+            $this->assertEquals($time, $totp->referenceTime());
         }
     }
 
@@ -1755,12 +1753,12 @@ class TotpTest extends TestCase
     }
 
     /**
-     * Date provider for testReferenceDateTime().
+     * Date provider for testReferenceTime().
      *
      * @return array The test data.
      * @noinspection PhpDocMissingThrowsInspection DateTime constructor shouldn't throw with test data.
      */
-    public function dataForTestReferenceDateTime(): array
+    public function dataForTestReferenceTime(): array
     {
         $now = time();
 
@@ -1795,12 +1793,12 @@ class TotpTest extends TestCase
     }
 
     /**
-     * @dataProvider dataForTestReferenceDateTime
+     * @dataProvider dataForTestReferenceTime
      *
      * @param int|\DateTime $time The time to set in the Totp as the reference.
-     * @param DateTime|null $expectedDateTime What referenceDateTime() is expected to return.
+     * @param DateTime|null $expectedDateTime What referenceTime() is expected to return.
      */
-    public function testReferenceDateTime(int|DateTime $time, ?DateTime $expectedDateTime = null): void
+    public function testReferenceTime(int|DateTime $time, ?DateTime $expectedDateTime = null): void
     {
         if (!isset($expectedDateTime)) {
             if (!($time instanceof DateTime)) {
@@ -1812,7 +1810,7 @@ class TotpTest extends TestCase
 
         $totp = self::createTotp();
         $totp->setReferenceTime($time);
-        $actual = $totp->referenceDateTime();
+        $actual = $totp->referenceTime();
         $this->assertInstanceOf(DateTime::class, $actual);
         $this->assertEquals($expectedDateTime, $actual);
     }
@@ -2336,12 +2334,12 @@ class TotpTest extends TestCase
     }
 
     /**
-     * Test data for the currentPassword() method.
+     * Test data for the password() method.
      *
      * @return array The test data.
      * @noinspection PhpDocMissingThrowsInspection DateTime constructor shouldn't throw with test data.
      */
-    public function dataForTestCurrentHmac(): array
+    public function dataForTestHmac(): array
     {
         /** @noinspection PhpUnhandledExceptionInspection DateTime constructor shouldn't throw with test data. */
         return [
@@ -2367,21 +2365,21 @@ class TotpTest extends TestCase
     }
 
     /**
-     * Test for Totp::currentHmac().
+     * Test for Totp::hmac().
      *
-     * @dataProvider dataForTestCurrentHmac
+     * @dataProvider dataForTestHmac
      *
      * @param string|null $secret The TOTP secret. If null, a random secret will be chosen.
      * @param int $digits The number of digits for the password. Defaults to 6.
      * @param string $algorithm The hash algorithm to use. Defaults to Totp::Sha1Algorithm.
      * @param int|\DateTime $referenceTime The reference time for the TOTP. Defaults to 0, the Unix epoch.
      *
-     * @noinspection PhpDocMissingThrowsInspection Totp constructor, currentHmac() and hmacAt() should not throw with
+     * @noinspection PhpDocMissingThrowsInspection Totp constructor, hmac() and hmacAt() should not throw with
      * test data.
      */
-    public function testCurrentHmac(string $secret = null, int $digits = 6, string $algorithm = Totp::Sha1Algorithm, int|DateTime $referenceTime = 0): void
+    public function testHmac(string $secret = null, int $digits = 6, string $algorithm = Totp::Sha1Algorithm, int|DateTime $referenceTime = 0): void
     {
-        // The logic behind this test is this: currentPassword() can't return a pre-known value because it produces a
+        // The logic behind this test is this: password() can't return a pre-known value because it produces a
         // password dependent on an external factor - the current system time. So we use passwordAt() as our source of
         // expectations on the assumption that it provides a correct value. It's safe to do this because we have a test
         // for passwordAt() and that test will tell us if it's not working. In order mitigate against the outside chance
@@ -2390,7 +2388,7 @@ class TotpTest extends TestCase
         // the time after retrieving the password from the Totp object is the same as the time we're using as our
         // source of expectation.
         //
-        // Note that while debugging, if you put a breakpoint on the call to Totp::currentPassword() you are more likely
+        // Note that while debugging, if you put a breakpoint on the call to Totp::password() you are more likely
         // to trigger a repeat of the loop
         /** @noinspection PhpUnhandledExceptionInspection Totp constructor should not throw with test data. */
         $totp = new Totp(secret: $secret, renderer: new Integer($digits), referenceTime: $referenceTime, hashAlgorithm: $algorithm);
@@ -2398,8 +2396,8 @@ class TotpTest extends TestCase
         // unless you've set a breakpoint we should traverse this loop no more than twice
         do {
             $time = time();
-            /** @noinspection PhpUnhandledExceptionInspection currentHmac() should not throw with test data. */
-            $actual = $totp->currentHmac();
+            /** @noinspection PhpUnhandledExceptionInspection hmac() should not throw with test data. */
+            $actual = $totp->hmac();
             $repeat = (time() !== $time);
         } while ($repeat);
 
@@ -2462,17 +2460,17 @@ class TotpTest extends TestCase
             "Unexpected HMAC at " .
             ($currentTime instanceof DateTime ? $currentTime : new DateTime("@{$currentTime}"))->format("Y-m-d H:i:s") .
             " with secret '" . self::hexOf($secret) . "', algorithm {$totp->hashAlgorithm()}, reference time " .
-            $totp->referenceDateTime()->format("Y-m-d H:i:s") . ", time step {$totp->timeStep()}"
+            $totp->referenceTime()->format("Y-m-d H:i:s") . ", time step {$totp->timeStep()}"
         );
     }
 
     /**
-     * Test data for the currentPassword() method.
+     * Test data for the password() method.
      *
      * @return array The test data.
      * @noinspection PhpDocMissingThrowsInspection DateTime constructor shouldn't throw with test data.
      */
-    public function dataForTestCurrentPassword(): array
+    public function dataForTestPassword(): array
     {
         /** @noinspection PhpUnhandledExceptionInspection DateTime constructor shouldn't throw with test data. */
         return [
@@ -2498,7 +2496,7 @@ class TotpTest extends TestCase
     }
 
     /**
-     * @dataProvider dataForTestCurrentPassword
+     * @dataProvider dataForTestPassword
      *
      * @param string|null $secret The TOTP secret. If null, a random secret will be chosen.
      * @param int $digits The number of digits for the password. Defaults to 6.
@@ -2506,11 +2504,11 @@ class TotpTest extends TestCase
      * @param int|\DateTime $referenceTime The reference time for the TOTP. Defaults to 0, the Unix epoch.
      *
      * @noinspection PhpDocMissingThrowsInspection Totp constructor and Integer renderer constructor should not throw
-     * with test data. Totp::currentPassword() and Totp::passwordAt() should not throw with test data.
+     * with test data. Totp::password() and Totp::passwordAt() should not throw with test data.
      */
-    public function testCurrentPassword(string $secret = null, int $digits = 6, string $algorithm = Totp::Sha1Algorithm, int|DateTime $referenceTime = 0): void
+    public function testPassword(string $secret = null, int $digits = 6, string $algorithm = Totp::Sha1Algorithm, int|DateTime $referenceTime = 0): void
     {
-        // The logic behind this test is this: currentPassword() can't return a pre-known value because it produces a
+        // The logic behind this test is this: password() can't return a pre-known value because it produces a
         // password dependent on an external factor - the current system time. So we use passwordAt() as our source of
         // expectations on the assumption that it provides a correct value. It's safe to do this because we have a test
         // for passwordAt() and that test will tell us if it's not working. In order mitigate against the outside chance
@@ -2519,7 +2517,7 @@ class TotpTest extends TestCase
         // the time after retrieving the password from the Totp object is the same as the time we're using as our
         // source of expectation.
         //
-        // Note that while debugging, if you put a breakpoint on the call to Totp::currentPassword() you are more likely
+        // Note that while debugging, if you put a breakpoint on the call to Totp::password() you are more likely
         // to trigger a repeat of the loop
         /** @noinspection PhpUnhandledExceptionInspection Totp constructor and Integer renderer constructor should not
          * throw with test data.
@@ -2529,8 +2527,8 @@ class TotpTest extends TestCase
         // unless you've set a breakpoint we should traverse this loop no more than twice
         do {
             $time = time();
-            /** @noinspection PhpUnhandledExceptionInspection currentPassword() should not throw with test data. */
-            $actual = $totp->currentPassword();
+            /** @noinspection PhpUnhandledExceptionInspection password() should not throw with test data. */
+            $actual = $totp->password();
             $repeat = (time() !== $time);
         } while ($repeat);
 
@@ -2600,7 +2598,7 @@ class TotpTest extends TestCase
                 "Unexpected {$digits}-digit password at " .
                 ($currentTime instanceof DateTime ? $currentTime : new DateTime("@{$currentTime}"))->format("Y-m-d H:i:s") .
                 " with secret '" . self::hexOf($secret) . "', algorithm {$totp->hashAlgorithm()}, reference time " .
-                $totp->referenceDateTime()->format("Y-m-d H:i:s") . ", time step {$totp->timeStep()}"
+                $totp->referenceTime()->format("Y-m-d H:i:s") . ", time step {$totp->timeStep()}"
             );
 
             $password = substr($password, 1);
@@ -2639,14 +2637,14 @@ class TotpTest extends TestCase
      * @param int|\DateTime $referenceTime The reference time for the TOTP. Defaults to 0, the Unix epoch.
      *
      * @noinspection PhpDocMissingThrowsInspection Totp constructor, Integer renderer constructor,
-     * Totp::currentPassword() and Totp::verify() shouldn't throw with test data.
+     * Totp::password() and Totp::verify() shouldn't throw with test data.
      */
     public function testVerify(string $secret = null, int $digits = 6, string $algorithm = Totp::Sha1Algorithm, int|DateTime $referenceTime = 0): void
     {
         // The logic behind this test is this: verify() can't return a pre-known value because it is dependent on an
         // external factor - the current system time. So we fetch the current password, which we know should pass
-        // verification, and verify that on the assumption that currentPassword() provides the correct value. It's
-        // safe to do this because we have a test for currentPassword() and that test will tell us if it's not working.
+        // verification, and verify that on the assumption that password() provides the correct value. It's
+        // safe to do this because we have a test for password() and that test will tell us if it's not working.
         // In order mitigate against the outside chance that the system time ticks over to the next TOTP time step
         // between the point in time at which we call time() and the point in time at which we do the verification, we
         // ensure that the time after doing the verification is the same as the time before it, ensuring that we've
@@ -2664,7 +2662,7 @@ class TotpTest extends TestCase
         do {
             $time = time();
             /** @noinspection PhpUnhandledExceptionInspection Shouldn't throw with test data. */
-            $correctPassword = $totp->currentPassword();
+            $correctPassword = $totp->password();
             // change one digit of the correct password by one, making it incorrect
             $incorrectPassword    = $correctPassword;
             $incorrectPassword[3] = "" . ((intval($incorrectPassword[3]) + 1) % 10);

--- a/tools/dev/random-totp.php
+++ b/tools/dev/random-totp.php
@@ -73,8 +73,8 @@ $counterBytesAt = $counterBytesAt->getClosure($totp);
 echo "Secret         : " . toPhpHexString($totp->secret()) . "\n";
 echo "Secret (B32)   : {$totp->base32Secret()}\n";
 echo "Secret (B64)   : {$totp->base64Secret()}\n";
-echo "Reference Time : {$totp->referenceTimestamp()} {$totp->referenceDateTime()->format("Y-m-d H:i:s T")}\n";
-echo "Time step       : {$totp->timeStep()}\n";
+echo "Reference Time : {$totp->referenceTimestamp()} {$totp->referenceTime()->format("Y-m-d H:i:s T")}\n";
+echo "Time step      : {$totp->timeStep()}\n";
 echo "Current Time   : {$currentTime} " . (new DateTime("@{$currentTime}"))->format("Y-m-d H:i:s T") . "\n\n";
 
 // OTP details at current time


### PR DESCRIPTION
- added missing return types in Base32 and Base64
- fixed incorrect reference to Base32 in docs for Base64
- added extra class docs for SixDigits and EightDigits renderer classes
- renamed extractIntFromHmac() to extractIntegerFromHmac() in
  ExtractsStandard31BitInteger renderer trait
- reordered traits and consts in Integer renderer class
- all references to algorithm now use hash algorithm for consistency.
  The UrlGenerator class is an exception since the URL parameter for
  the hash algorithm is just "algorithm" so it makes more sense for that
  class to use this in its naming
- added doc for property in InvalidSecretException
- InvalidTimeException now accepts DateTime objects
- renamed InvalidTimeException::getDateTime() as
  InvalidTimeException::getTime() for consistency
- added class docs for SecureRandomDataUnavailableException
- call to randomSecret() in Totp constructor now uses late static
  binding
- renamed Totp::referenceDateTime() as referenceTime() for consistency
- removed "current" from all Totp method names that work with the
  current time.
- TotpSecret m_raw property type changed to string from nullable string
  (it's always set)
- Reordered union type members in UnsupportedReferenceTimeException for
  consistency with other classes that handle times as DateTime objects
  or Unix timestamps
- UnsupportedReferenceTimeException only populates the property for the
  unsupported time in the type that wasn't supplied in the constructor
  when it is first requested
- fixed "invalid" that should have been "unsupported in docs for
  UnsupportedRendererException
- added missing @throws annotations for static/fluent methods in
  UrlGenerator
- added annotations hinting the IDE not to warn about polymorphic calls
  that have guards ensuring the method is available