### PR TITLE
remove extra /

### DIFF
--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -326,7 +326,7 @@ class UrlGenerator
             $url .= urlencode($this->user());
         }
 
-        $url .= "/?secret={$totp->base32Secret()}";
+        $url .= "?secret={$totp->base32Secret()}";
 
         if ($this->hasIssuer()) {
             $url .= "&issuer=" . urlencode($this->issuer());


### PR DESCRIPTION
As per https://www.ietf.org/archive/id/draft-linuxgemini-otpauth-uri-00.html, this `/` is unnecessary. When scanning a QR Code of the URL, it adds an extra `/` to the end of the user's name/identifier