### PR TITLE
PT-14 use totp random secret in all unit tests where random secrets are required

### DIFF
--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -513,7 +513,6 @@ final class FactoryTest extends TestCase
      */
     public function testRandomSecret1(): void
     {
-        // NOTE can't test case where randomSecret() throws because we can't force random_bytes() to throw
         for ($idx = 0; $idx < 100; ++$idx) {
             self::assertGreaterThanOrEqual(64, strlen(Factory::randomSecret()->raw()), "randomSecret() did not return a sufficiently large byte sequence.");
         }

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -467,7 +467,7 @@ final class UrlGeneratorTest extends TestCase
         for ($idx = 0; $idx < 100; ++$idx) {
             $user         = self::randomUser();
             $issuer       = self::randomIssuer();
-            $secret       = self::randomValidSecret();
+            $secret = Factory::randomSecret()->raw();
             $base32Secret = Base32::encode($secret);
 
             $yield = [

--- a/tests/UrlGeneratorTest.php
+++ b/tests/UrlGeneratorTest.php
@@ -465,8 +465,8 @@ final class UrlGeneratorTest extends TestCase
 
         // 100 random valid setups
         for ($idx = 0; $idx < 100; ++$idx) {
-            $user         = self::randomUser();
-            $issuer       = self::randomIssuer();
+            $user   = self::randomUser();
+            $issuer = self::randomIssuer();
             $secret = Factory::randomSecret()->raw();
             $base32Secret = Base32::encode($secret);
 


### PR DESCRIPTION
Some minor tidying-up in tests:

- Remove a misleading comment.
- Use the Factory's random secret generator where possible.